### PR TITLE
Fix incorrect error connecting to v4.1.1+ server (+ minor doc update)

### DIFF
--- a/source/mysql/connection.d
+++ b/source/mysql/connection.d
@@ -8,8 +8,7 @@
  * It has no dependecies on GPL header files or libraries, instead communicating directly with the server via the
  * published client/server protocol.
  *
- * $(LINK http://forge.mysql.com/wiki/MySQL_Internals_ClientServer_Protocol)$(BR)
- * $(LINK http://forge.mysql.com/w/index.php?title=MySQL_Internals_ClientServer_Protocol&diff=5078&oldid=4374)
+ * $(LINK http://dev.mysql.com/doc/internals/en/client-server-protocol.html)$(BR)
  *
  * This version is not by any means comprehensive, and there is still a good deal of work to do. As a general design
  * position it avoids providing wrappers for operations that can be accomplished by simple SQL sommands, unless


### PR DESCRIPTION
Attempting to connect to a v5.0 MySQL server (and possibly others) resulted in an oddly contradictory "Server doesn't support protocol v4.1 passwords" error.

Turns out, this was a bug based on a misinterpretation of the protocol spec (or perhaps an outdated version of the spec). Specifically, the low bit of the server capabilities does _not_ refer to the new 4.1+ style passwords (as was previously thought), but rather a later version of the _old_-style passwords (rather conflusingly). The flag itself was deprecated in v4.1.1 and, according top the spec, should be _assumed_ to be ON. See:
- http://dev.mysql.com/doc/internals/en/connection-phase.html#capability-flags
- http://jan.kneschke.de/2012/2/23/client_long_password/

I also snuck in a few minor documentation updates:
- Fixed a few broken links to the protocol spec.
- Removed the blurb about "only compiled and tested on Ubuntu with D2.055" since that's no longer true. (I've been using it on Windows with DMD 2.059 and 2.060.)
- Added note that MySQL servers prior to v4.1.1 are not supported (which was already true anyway, the docs just didn't say so).
