### PR TITLE
[Trivial]Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.[oa]
+*.so
+*.lib
+*.dll
+*.exe
+.dub
+
+# Executable file name when 'dub' is run on linux
+mysql-native


### PR DESCRIPTION
Same as [this issue](https://github.com/rejectedsoftware/vibe.d/pull/534). The rationale for these apparently useless changes is to avoid having a dirty flag on a submodule with git.
