### PR TITLE
fixed decoding LCB value for large feilds

### DIFF
--- a/source/mysql/connection.d
+++ b/source/mysql/connection.d
@@ -1373,7 +1373,41 @@ body
     if(lcb.isNull || lcb.isIncomplete)
         return lcb;
     assert(packet.length >= lcb.totalBytes);
-    lcb.value = packet.decode!ulong(lcb.numBytes);
+    //lcb.value = packet.decode!ulong(lcb.numBytes);
+    lcb.value = 0;
+	switch (lcb.numBytes)
+	{
+		case 0: // Null - only for Row Data Packet
+			lcb.value = 0;
+			break;
+		case 8: // 64-bit
+			lcb.value |= packet[8];
+			lcb.value <<= 8;
+			lcb.value |= packet[7];
+			lcb.value <<= 8;
+			lcb.value |= packet[6];
+			lcb.value <<= 8;
+			lcb.value |= packet[5];
+			lcb.value <<= 8;
+			lcb.value |= packet[4];
+			lcb.value <<= 8;
+			goto case;
+		case 3: // 24-bit
+			lcb.value |= packet[3];
+			lcb.value <<= 8;
+			goto case;
+		case 2: // 16-bit
+			lcb.value |= packet[2];
+			lcb.value <<= 8;
+			lcb.value |= packet[1];
+			break;
+		case 1: // 8-bit
+			lcb.value = cast(ulong)packet[0];
+			break;
+		default:
+			assert(0);
+	}
+
     return lcb;
 }
 


### PR DESCRIPTION
fixed decoding LCB value for fields > 250 bytes.
according to this doc:
http://dev.mysql.com/doc/internals/en/event-content-writing-conventions.html

Current implementation ignored this and was hanging waiting for more packets when VARCHAR was larger than 250 bytes.

There is also parseLCB function that is doing this exactly,
but it seems to be not used since commit 01b30f17218212a9aba6bfc6778f8dbaa962e1d6

this probably fixes #18
