### PR TITLE
Use vibe-d sub package dependency and a more current version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"Nick Sabalausky"
 	],
 	"dependencies": {
-		"vibe-d": {"version": ">=0.7.17", "optional": true}
+		"vibe-d:core": {"version": "~>0.7.28", "optional": true}
 	},
 	"configurations": [
 	 	{


### PR DESCRIPTION
The old dependency caused the whole of the vibe.d package to be compiled instead of only the core parts that are used by mysql-native itself. See dlang/dub#899.