### PR TITLE
Prevent segfault on copying ResultRange.

### DIFF
--- a/source/mysql/result.d
+++ b/source/mysql/result.d
@@ -463,7 +463,7 @@ public:
 	/// Check whether the range can still we used, or has been invalidated
 	@property bool isValid() const pure nothrow
 	{
-		return _commandID == _con.lastCommandID;
+		return _con !is null && _commandID == _con.lastCommandID;
 	}
 
 	/// Make the ResultRange behave as an input range - empty


### PR DESCRIPTION
Simple reproduction:

```D
import mysql;
void main()
{
   ResultRange r1;
   r1 = r1;
}
```