### PR TITLE
sockets.d(21,27): Error: undefined identifier 'vibe.core.net.TCPConnection'

### DIFF
--- a/source/mysql/protocol/sockets.d
+++ b/source/mysql/protocol/sockets.d
@@ -18,6 +18,7 @@ version(Have_vibe_d_core)
 alias PlainPhobosSocket = std.socket.TcpSocket;
 version(Have_vibe_d_core)
 {
+	static import vibe.core.net;
 	alias PlainVibeDSocket = vibe.core.net.TCPConnection;
 }
 else


### PR DESCRIPTION
When compiling in singleFile mode, I get a compilation error:

```
> dub test --build-mode=singleFile    

Generating test runner configuration 'masterserver-test-unix' for 'unix' (executable).
Performing "unittest" build using dmd for x86_64.
vibe-d:utils 0.7.32: target for configuration "library" is up to date.
vibe-d:data 0.7.32: target for configuration "library" is up to date.
vibe-d:core 0.7.32: target for configuration "libevent" is up to date.
mysql-native 1.1.0: building configuration "library"...
Compiling ../../.dub/packages/mysql-native-1.1.0/mysql-native/source/mysql/commands.d...
Compiling ../../.dub/packages/mysql-native-1.1.0/mysql-native/source/mysql/connection.d...
Compiling ../../.dub/packages/mysql-native-1.1.0/mysql-native/source/mysql/db.d...
Compiling ../../.dub/packages/mysql-native-1.1.0/mysql-native/source/mysql/escape.d...
Compiling ../../.dub/packages/mysql-native-1.1.0/mysql-native/source/mysql/exceptions.d...
Compiling ../../.dub/packages/mysql-native-1.1.0/mysql-native/source/mysql/metadata.d...
Compiling ../../.dub/packages/mysql-native-1.1.0/mysql-native/source/mysql/package.d...
Compiling ../../.dub/packages/mysql-native-1.1.0/mysql-native/source/mysql/pool.d...
Compiling ../../.dub/packages/mysql-native-1.1.0/mysql-native/source/mysql/prepared.d...
Compiling ../../.dub/packages/mysql-native-1.1.0/mysql-native/source/mysql/protocol/constants.d...
Compiling ../../.dub/packages/mysql-native-1.1.0/mysql-native/source/mysql/protocol/extra_types.d...
Compiling ../../.dub/packages/mysql-native-1.1.0/mysql-native/source/mysql/protocol/packet_helpers.d...
Compiling ../../.dub/packages/mysql-native-1.1.0/mysql-native/source/mysql/protocol/packets.d...
Compiling ../../.dub/packages/mysql-native-1.1.0/mysql-native/source/mysql/protocol/sockets.d...
../../.dub/packages/mysql-native-1.1.0/mysql-native/source/mysql/protocol/sockets.d(21,27): Error: undefined identifier 'vibe.core.net.TCPConnection'
dmd failed with exit code 1.

> dmd -v
DMD64 D Compiler v2.073.2
```

adding `static import vibe.core.net;` right above the error line fixed the problem for me.
