### PR TITLE
Prepared: Prevent mem allocs during cleanup

### DIFF
--- a/source/mysql/prepared.d
+++ b/source/mysql/prepared.d
@@ -1092,6 +1092,9 @@ public:
 	
 	This method tells the server that it can dispose of the information it
 	holds about the current prepared statement.
+
+	This method can be called during a GC collection. Allocations should be
+	avoided if possible as it could crash the GC.
 	+/
 	void release()
 	{
@@ -1100,8 +1103,11 @@ public:
 
 		scope(failure) _conn.kill();
 
-		ubyte[] packet;
-		packet.length = 9;
+		if (_conn.closed())
+			return;
+
+		ubyte[9] packet_buf;
+		ubyte[] packet = packet_buf;
 		packet.setPacketHeader(0/*packet number*/);
 		_conn.bumpPacket();
 		packet[4] = CommandType.STMT_CLOSE;


### PR DESCRIPTION
If a prepared statement is collected during a GC run and the d'tor is
called, it causes another allocation through either:

- allocation of the packet array
- allocation of an exception when trying to write to a closed connection

In both cases, the GC freaks out and throws an InvalidMemoryOperation.

This commit fixes the two allocation cases I found. There may be more.

Here is an example backtrace of this:
https://gist.github.com/Marenz/b3293f3a6daa9706a5552a4e68b1cec5