### PR TITLE
Fix issue #154 - mysql server closing socket causes connection to be unusable

### DIFF
--- a/source/mysql/connection.d
+++ b/source/mysql/connection.d
@@ -468,6 +468,10 @@ package:
 		if(_socket.connected)
 			_socket.close();
 		_open = OpenState.notConnected;
+		// any pending data is gone. Any statements to release will be released
+		// on the server automatically.
+		_headersPending = _rowsPending = _binaryPending = false;
+		statementsToRelease.clear();
 	}
 	
 	/// Called whenever mysql-native needs to send a command to the server
@@ -484,10 +488,19 @@ package:
 			
 		isAutoPurging = true;
 		scope(exit) isAutoPurging = false;
-		scope(failure) kill();
 
-		purgeResult();
-		statementsToRelease.releaseAll();
+		try
+		{
+			purgeResult();
+			statementsToRelease.releaseAll();
+		}
+		catch(Exception e)
+		{
+			// likely the connection was closed, so reset any state.
+			// Don't treat this as a real error, because everything will be reset when we
+			// reconnect.
+			kill();
+		}
 	}
 
 	/++
@@ -527,8 +540,17 @@ package:
 			if(id != 0)
 				doRelease(conn, id);
 
-			ids.length = 0;
-			assumeSafeAppend(ids);
+			clear();
+		}
+
+		// clear all statements, and reset for using again.
+		private void clear()
+		{
+			if(ids.length)
+			{
+				ids.length = 0;
+				assumeSafeAppend(ids);
+			}
 		}
 	}
 	StatementsToRelease!(PreparedImpl.immediateRelease) statementsToRelease;


### PR DESCRIPTION
In my use cases, I'm leaving open the connection to the mysql server to avoid having to do the connection handshake for every transaction.

However, periodically, the mysql server will close the connection, leaving the application to figure out how to deal with it.

The current code will kill the connection, but this simply closes the socket (which is already closed), and does not actually reset any other state. In particular, deferred cleanup via autoPurge is not reset.

In this update, I'm resetting all cleanup state in the kill function, and ignoring any exceptions during autoPurge. Ignoring all exceptions is OK, because we are going to kill the connection if this happens, and if it does, the server is going to clean up the mess for us (release any prepared statements, and flush any unread data).