### PR TITLE
replace all usages of enforceEx by enforce

### DIFF
--- a/source/mysql/commands.d
+++ b/source/mysql/commands.d
@@ -374,7 +374,7 @@ package ResultRange queryImpl(ColumnSpecialization[] csa,
 	Connection conn, ExecQueryImplInfo info)
 {
 	ulong ra;
-	enforceEx!MYXNoResultRecieved(execQueryImpl(conn, info, ra));
+	enforce!MYXNoResultRecieved(execQueryImpl(conn, info, ra));
 
 	conn._rsh = ResultSetHeaders(conn, conn._fieldCount);
 	if(csa !is null)
@@ -565,15 +565,15 @@ void queryRowTuple(T...)(Connection conn, ref BackwardCompatPrepared prepared, r
 package void queryRowTupleImpl(T...)(Connection conn, ExecQueryImplInfo info, ref T args)
 {
 	ulong ra;
-	enforceEx!MYXNoResultRecieved(execQueryImpl(conn, info, ra));
+	enforce!MYXNoResultRecieved(execQueryImpl(conn, info, ra));
 
 	Row rr = conn.getNextRow();
 	/+if (!rr._valid)   // The result set was empty - not a crime.
 		return;+/
-	enforceEx!MYX(rr._values.length == args.length, "Result column count does not match the target tuple.");
+	enforce!MYX(rr._values.length == args.length, "Result column count does not match the target tuple.");
 	foreach (size_t i, dummy; args)
 	{
-		enforceEx!MYX(typeid(args[i]).toString() == rr._values[i].type.toString(),
+		enforce!MYX(typeid(args[i]).toString() == rr._values[i].type.toString(),
 			"Tuple "~to!string(i)~" type and column type are not compatible.");
 		args[i] = rr._values[i].get!(typeof(args[i]));
 	}

--- a/source/mysql/connection.d
+++ b/source/mysql/connection.d
@@ -619,7 +619,7 @@ public:
 	this(MySQLSocketType socketType, string host, string user, string pwd, string db, ushort port = 3306, SvrCapFlags capFlags = defaultClientFlags)
 	{
 		version(Have_vibe_d_core) {} else
-			enforceEx!MYX(socketType != MySQLSocketType.vibed, "Cannot use Vibe.d sockets without -version=Have_vibe_d_core");
+			enforce!MYX(socketType != MySQLSocketType.vibed, "Cannot use Vibe.d sockets without -version=Have_vibe_d_core");
 
 		this(socketType, &defaultOpenSocketPhobos, &defaultOpenSocketVibeD,
 			host, user, pwd, db, port, capFlags);
@@ -654,10 +654,10 @@ public:
 	}
 	body
 	{
-		enforceEx!MYX(capFlags & SvrCapFlags.PROTOCOL41, "This client only supports protocol v4.1");
-		enforceEx!MYX(capFlags & SvrCapFlags.SECURE_CONNECTION, "This client only supports protocol v4.1 connection");
+		enforce!MYX(capFlags & SvrCapFlags.PROTOCOL41, "This client only supports protocol v4.1");
+		enforce!MYX(capFlags & SvrCapFlags.SECURE_CONNECTION, "This client only supports protocol v4.1 connection");
 		version(Have_vibe_d_core) {} else
-			enforceEx!MYX(socketType != MySQLSocketType.vibed, "Cannot use Vibe.d sockets without -version=Have_vibe_d_core");
+			enforce!MYX(socketType != MySQLSocketType.vibed, "Cannot use Vibe.d sockets without -version=Have_vibe_d_core");
 
 		_socketType = socketType;
 		_host = host;
@@ -877,7 +877,7 @@ public:
 		foreach (s; a)
 		{
 			string[] a2 = split(s, "=");
-			enforceEx!MYX(a2.length == 2, "Bad connection string: " ~ cs);
+			enforce!MYX(a2.length == 2, "Bad connection string: " ~ cs);
 			string name = strip(a2[0]);
 			string val = strip(a2[1]);
 			switch (name)

--- a/source/mysql/metadata.d
+++ b/source/mysql/metadata.d
@@ -85,7 +85,7 @@ private:
 
 	MySQLProcedure[] stored(bool procs)
 	{
-		enforceEx!MYX(_con.currentDB.length, "There is no selected database");
+		enforce!MYX(_con.currentDB.length, "There is no selected database");
 		string query = procs ? "SHOW PROCEDURE STATUS WHERE db='": "SHOW FUNCTION STATUS WHERE db='";
 		query ~= _con.currentDB ~ "'";
 

--- a/source/mysql/prepared.d
+++ b/source/mysql/prepared.d
@@ -223,7 +223,7 @@ public:
 		// in the variant array, or provided explicitly. This sucks, but short of
 		// having a client side SQL parser I don't see what can be done.
 
-		enforceEx!MYX(index < _numParams, "Parameter index out of range.");
+		enforce!MYX(index < _numParams, "Parameter index out of range.");
 
 		_inParams[index] = val;
 		psn.pIndex = index;
@@ -299,7 +299,7 @@ public:
 	void setArgs(T...)(T args)
 		if(T.length == 0 || !is(T[0] == Variant[]))
 	{
-		enforceEx!MYX(args.length == _numParams, "Argument list supplied does not match the number of parameters.");
+		enforce!MYX(args.length == _numParams, "Argument list supplied does not match the number of parameters.");
 
 		foreach (size_t i, arg; args)
 			setArg(i, arg);
@@ -337,7 +337,7 @@ public:
 	+/
 	void setArgs(Variant[] args, ParameterSpecialization[] psnList=null)
 	{
-		enforceEx!MYX(args.length == _numParams, "Param count supplied does not match prepared statement");
+		enforce!MYX(args.length == _numParams, "Param count supplied does not match prepared statement");
 		_inParams[] = args[];
 		if (psnList !is null)
 		{
@@ -355,7 +355,7 @@ public:
 	+/
 	Variant getArg(size_t index)
 	{
-		enforceEx!MYX(index < _numParams, "Parameter index out of range.");
+		enforce!MYX(index < _numParams, "Parameter index out of range.");
 		return _inParams[index];
 	}
 

--- a/source/mysql/protocol/extra_types.d
+++ b/source/mysql/protocol/extra_types.d
@@ -18,15 +18,15 @@ struct SQLValue
 	// empty template as a template and non-template won't be added to the same overload set
 	@property inout(Variant) value()() inout
 	{
-		enforceEx!MYX(!isNull, "SQL value is null");
-		enforceEx!MYX(!isIncomplete, "SQL value not complete");
+		enforce!MYX(!isNull, "SQL value is null");
+		enforce!MYX(!isIncomplete, "SQL value not complete");
 		return _value;
 	}
 
 	@property void value(T)(T value)
 	{
-		enforceEx!MYX(!isNull, "SQL value is null");
-		enforceEx!MYX(!isIncomplete, "SQL value not complete");
+		enforce!MYX(!isNull, "SQL value is null");
+		enforce!MYX(!isIncomplete, "SQL value not complete");
 		_value = value;
 	}
 

--- a/source/mysql/protocol/packet_helpers.d
+++ b/source/mysql/protocol/packet_helpers.d
@@ -27,10 +27,10 @@ Returns: A populated or default initialized TimeDiff struct.
 +/
 TimeDiff toTimeDiff(in ubyte[] a) pure
 {
-	enforceEx!MYXProtocol(a.length, "Supplied byte array is zero length");
+	enforce!MYXProtocol(a.length, "Supplied byte array is zero length");
 	TimeDiff td;
 	uint l = a[0];
-	enforceEx!MYXProtocol(l == 0 || l == 5 || l == 8 || l == 12, "Bad Time length in binary row.");
+	enforce!MYXProtocol(l == 0 || l == 5 || l == 8 || l == 12, "Bad Time length in binary row.");
 	if (l >= 5)
 	{
 		td.negative = (a[1]  != 0);
@@ -66,9 +66,9 @@ TimeDiff toTimeDiff(string s)
 	}
 	td.hours    = cast(ubyte) t%24;
 	td.days     = cast(ubyte) t/24;
-	enforceEx!MYXProtocol(s.skipOver(":"), `Expected: ":"`);
+	enforce!MYXProtocol(s.skipOver(":"), `Expected: ":"`);
 	td.minutes  = parse!ubyte(s);
-	enforceEx!MYXProtocol(s.skipOver(":"), `Expected: ":"`);
+	enforce!MYXProtocol(s.skipOver(":"), `Expected: ":"`);
 	td.seconds  = parse!ubyte(s);
 	return td;
 }
@@ -85,10 +85,10 @@ Returns: A populated or default initialized std.datetime.TimeOfDay struct.
 +/
 TimeOfDay toTimeOfDay(in ubyte[] a) pure
 {
-	enforceEx!MYXProtocol(a.length, "Supplied byte array is zero length");
+	enforce!MYXProtocol(a.length, "Supplied byte array is zero length");
 	uint l = a[0];
-	enforceEx!MYXProtocol(l == 0 || l == 5 || l == 8 || l == 12, "Bad Time length in binary row.");
-	enforceEx!MYXProtocol(l >= 8, "Time column value is not in a time-of-day format");
+	enforce!MYXProtocol(l == 0 || l == 5 || l == 8 || l == 12, "Bad Time length in binary row.");
+	enforce!MYXProtocol(l >= 8, "Time column value is not in a time-of-day format");
 
 	TimeOfDay tod;
 	tod.hour    = a[6];
@@ -109,10 +109,10 @@ TimeOfDay toTimeOfDay(string s)
 {
 	TimeOfDay tod;
 	tod.hour = parse!int(s);
-	enforceEx!MYXProtocol(tod.hour <= 24 && tod.hour >= 0, "Time column value is in time difference form");
-	enforceEx!MYXProtocol(s.skipOver(":"), `Expected: ":"`);
+	enforce!MYXProtocol(tod.hour <= 24 && tod.hour >= 0, "Time column value is in time difference form");
+	enforce!MYXProtocol(s.skipOver(":"), `Expected: ":"`);
 	tod.minute = parse!ubyte(s);
-	enforceEx!MYXProtocol(s.skipOver(":"), `Expected: ":"`);
+	enforce!MYXProtocol(s.skipOver(":"), `Expected: ":"`);
 	tod.second = parse!ubyte(s);
 	return tod;
 }
@@ -157,11 +157,11 @@ Returns: A populated or default initialized `std.datetime.Date` struct.
 +/
 Date toDate(in ubyte[] a) pure
 {
-	enforceEx!MYXProtocol(a.length, "Supplied byte array is zero length");
+	enforce!MYXProtocol(a.length, "Supplied byte array is zero length");
 	if (a[0] == 0)
 		return Date(0,0,0);
 
-	enforceEx!MYXProtocol(a[0] >= 4, "Binary date representation is too short");
+	enforce!MYXProtocol(a[0] >= 4, "Binary date representation is too short");
 	int year    = (a[2]  << 8) + a[1];
 	int month   = cast(int) a[3];
 	int day     = cast(int) a[4];
@@ -179,9 +179,9 @@ Returns: A populated or default initialized `std.datetime.Date` struct.
 Date toDate(string s)
 {
 	int year = parse!(ushort)(s);
-	enforceEx!MYXProtocol(s.skipOver("-"), `Expected: "-"`);
+	enforce!MYXProtocol(s.skipOver("-"), `Expected: "-"`);
 	int month = parse!(ubyte)(s);
-	enforceEx!MYXProtocol(s.skipOver("-"), `Expected: "-"`);
+	enforce!MYXProtocol(s.skipOver("-"), `Expected: "-"`);
 	int day = parse!(ubyte)(s);
 	return Date(year, month, day);
 }
@@ -227,11 +227,11 @@ Returns: A populated or default initialized `std.datetime.DateTime` struct.
 +/
 DateTime toDateTime(in ubyte[] a) pure
 {
-	enforceEx!MYXProtocol(a.length, "Supplied byte array is zero length");
+	enforce!MYXProtocol(a.length, "Supplied byte array is zero length");
 	if (a[0] == 0)
 		return DateTime();
 
-	enforceEx!MYXProtocol(a[0] >= 4, "Supplied ubyte[] is not long enough");
+	enforce!MYXProtocol(a[0] >= 4, "Supplied ubyte[] is not long enough");
 	int year    = (a[2] << 8) + a[1];
 	int month   =  a[3];
 	int day     =  a[4];
@@ -242,7 +242,7 @@ DateTime toDateTime(in ubyte[] a) pure
 	}
 	else
 	{
-		enforceEx!MYXProtocol(a[0] >= 7, "Supplied ubyte[] is not long enough");
+		enforce!MYXProtocol(a[0] >= 7, "Supplied ubyte[] is not long enough");
 		int hour    = a[5];
 		int minute  = a[6];
 		int second  = a[7];
@@ -262,15 +262,15 @@ Returns: A populated or default initialized `std.datetime.DateTime` struct.
 DateTime toDateTime(string s)
 {
 	int year = parse!(ushort)(s);
-	enforceEx!MYXProtocol(s.skipOver("-"), `Expected: "-"`);
+	enforce!MYXProtocol(s.skipOver("-"), `Expected: "-"`);
 	int month = parse!(ubyte)(s);
-	enforceEx!MYXProtocol(s.skipOver("-"), `Expected: "-"`);
+	enforce!MYXProtocol(s.skipOver("-"), `Expected: "-"`);
 	int day = parse!(ubyte)(s);
-	enforceEx!MYXProtocol(s.skipOver(" "), `Expected: " "`);
+	enforce!MYXProtocol(s.skipOver(" "), `Expected: " "`);
 	int hour = parse!(ubyte)(s);
-	enforceEx!MYXProtocol(s.skipOver(":"), `Expected: ":"`);
+	enforce!MYXProtocol(s.skipOver(":"), `Expected: ":"`);
 	int minute = parse!(ubyte)(s);
-	enforceEx!MYXProtocol(s.skipOver(":"), `Expected: ":"`);
+	enforce!MYXProtocol(s.skipOver(":"), `Expected: ":"`);
 	int second = parse!(ubyte)(s);
 	return DateTime(year, month, day, hour, minute, second);
 }
@@ -297,8 +297,8 @@ DateTime toDateTime(ulong x)
 	x /= 100;
 	int year   = cast(int) (x%10000);
 	// 2038-01-19 03:14:07
-	enforceEx!MYXProtocol(year >= 1970 &&  year < 2039, "Date/time out of range for 2 bit timestamp");
-	enforceEx!MYXProtocol(year != 2038 || (month < 1 && day < 19 && hour < 3 && minute < 14 && second < 7),
+	enforce!MYXProtocol(year >= 1970 &&  year < 2039, "Date/time out of range for 2 bit timestamp");
+	enforce!MYXProtocol(year != 2038 || (month < 1 && day < 19 && hour < 3 && minute < 14 && second < 7),
 			"Date/time out of range for 2 bit timestamp");
 	return DateTime(year, month, day, hour, minute, second);
 }
@@ -406,10 +406,10 @@ in
 }
 body
 {
-	enforceEx!MYXProtocol(packet.length, "Supplied byte array is zero length");
+	enforce!MYXProtocol(packet.length, "Supplied byte array is zero length");
 	uint length = packet.front;
-	enforceEx!MYXProtocol(length == 0 || length == 5 || length == 8 || length == 12, "Bad Time length in binary row.");
-	enforceEx!MYXProtocol(length >= 8, "Time column value is not in a time-of-day format");
+	enforce!MYXProtocol(length == 0 || length == 5 || length == 8 || length == 12, "Bad Time length in binary row.");
+	enforce!MYXProtocol(length >= 8, "Time column value is not in a time-of-day format");
 
 	packet.popFront(); // length
 	auto bytes = packet.consume(length);
@@ -444,7 +444,7 @@ body
 	if(numBytes == 0)
 		return DateTime();
 
-	enforceEx!MYXProtocol(numBytes >= 4, "Supplied packet is not large enough to store DateTime");
+	enforce!MYXProtocol(numBytes >= 4, "Supplied packet is not large enough to store DateTime");
 
 	int year    = packet.consume!ushort();
 	int month   = packet.consume!ubyte();
@@ -454,7 +454,7 @@ body
 	int second  = 0;
 	if(numBytes > 4)
 	{
-		enforceEx!MYXProtocol(numBytes >= 7, "Supplied packet is not large enough to store a DateTime with TimeOfDay");
+		enforce!MYXProtocol(numBytes >= 7, "Supplied packet is not large enough to store a DateTime with TimeOfDay");
 		hour    = packet.consume!ubyte();
 		minute  = packet.consume!ubyte();
 		second  = packet.consume!ubyte();
@@ -732,7 +732,7 @@ SQLValue consumeIfComplete()(ref ubyte[] packet, SQLType sqlType, bool binary, b
 			// See: http://dev.mysql.com/doc/internals/en/binary-protocol-value.html
 			if(sqlType == SQLType.BIT)
 			{
-				enforceEx!MYXProtocol(result.value.length == 1,
+				enforce!MYXProtocol(result.value.length == 1,
 					"Expected BIT to arrive as an LCB with length 1, but got length "~to!string(result.value.length));
 
 				result.value = result.value[0] == 1;
@@ -885,7 +885,7 @@ body
 	assert(!lcb.isIncomplete);
 	if(lcb.isNull)
 		return null;
-	enforceEx!MYXProtocol(lcb.value <= uint.max, "Protocol Length Coded String is too long");
+	enforce!MYXProtocol(lcb.value <= uint.max, "Protocol Length Coded String is too long");
 	return cast(string)packet.consume(cast(size_t)lcb.value).idup;
 }
 

--- a/source/mysql/protocol/packets.d
+++ b/source/mysql/protocol/packets.d
@@ -42,12 +42,12 @@ struct OKErrorPacket
 			packet.popFront(); // skip marker/field code
 			error = true;
 
-			enforceEx!MYXProtocol(packet.length > 2, "Malformed Error packet - Missing error code");
+			enforce!MYXProtocol(packet.length > 2, "Malformed Error packet - Missing error code");
 			serverStatus = packet.consume!short(); // error code into server state
 			if (packet.front == cast(ubyte) '#') //4.1+ error packet
 			{
 				packet.popFront(); // skip 4.1 marker
-				enforceEx!MYXProtocol(packet.length > 5, "Malformed Error packet - Missing SQL state");
+				enforce!MYXProtocol(packet.length > 5, "Malformed Error packet - Missing SQL state");
 				sqlState[] = (cast(char[])packet[0 .. 5])[];
 				packet = packet[5..$];
 			}
@@ -56,23 +56,23 @@ struct OKErrorPacket
 		{
 			packet.popFront(); // skip marker/field code
 
-			enforceEx!MYXProtocol(packet.length > 1, "Malformed OK packet - Missing affected rows");
+			enforce!MYXProtocol(packet.length > 1, "Malformed OK packet - Missing affected rows");
 			auto lcb = packet.consumeIfComplete!LCB();
 			assert(!lcb.isNull);
 			assert(!lcb.isIncomplete);
 			affected = lcb.value;
 
-			enforceEx!MYXProtocol(packet.length > 1, "Malformed OK packet - Missing insert id");
+			enforce!MYXProtocol(packet.length > 1, "Malformed OK packet - Missing insert id");
 			lcb = packet.consumeIfComplete!LCB();
 			assert(!lcb.isNull);
 			assert(!lcb.isIncomplete);
 			insertID = lcb.value;
 
-			enforceEx!MYXProtocol(packet.length > 2,
+			enforce!MYXProtocol(packet.length > 2,
 					format("Malformed OK packet - Missing server status. Expected length > 2, got %d", packet.length));
 			serverStatus = packet.consume!short();
 
-			enforceEx!MYXProtocol(packet.length >= 2, "Malformed OK packet - Missing warnings");
+			enforce!MYXProtocol(packet.length >= 2, "Malformed OK packet - Missing warnings");
 			warnings = packet.consume!short();
 		}
 		else
@@ -133,7 +133,7 @@ public:
 		_name           = packet.consume!LCS();
 		_originalName   = packet.consume!LCS();
 
-		enforceEx!MYXProtocol(packet.length >= 13, "Malformed field specification packet");
+		enforce!MYXProtocol(packet.length >= 13, "Malformed field specification packet");
 		packet.popFront(); // one byte filler here
 		_charSet    = packet.consume!short();
 		_length     = packet.consume!int();
@@ -335,14 +335,14 @@ public:
 		foreach (size_t i; 0 .. fieldCount)
 		{
 			auto packet = con.getPacket();
-			enforceEx!MYXProtocol(!packet.isEOFPacket(),
+			enforce!MYXProtocol(!packet.isEOFPacket(),
 					"Expected field description packet, got EOF packet in result header sequence");
 
 			_fieldDescriptions[i]   = FieldDescription(packet);
 			_fieldNames[i]          = _fieldDescriptions[i]._name;
 		}
 		auto packet = con.getPacket();
-		enforceEx!MYXProtocol(packet.isEOFPacket(),
+		enforce!MYXProtocol(packet.isEOFPacket(),
 				"Expected EOF packet in result header sequence");
 		auto eof = EOFPacket(packet);
 		con._serverStatus = eof._serverStatus;
@@ -367,7 +367,7 @@ public:
 	{
 		foreach(CSN csn; csa)
 		{
-			enforceEx!MYX(csn.cIndex < fieldCount && _fieldDescriptions[csn.cIndex].type == csn.type,
+			enforce!MYX(csn.cIndex < fieldCount && _fieldDescriptions[csn.cIndex].type == csn.type,
 					"Column specialization index or type does not match the corresponding column.");
 			_fieldDescriptions[csn.cIndex].chunkSize = csn.chunkSize;
 			_fieldDescriptions[csn.cIndex].chunkDelegate = csn.chunkDelegate;
@@ -439,13 +439,13 @@ public:
 			_con.getPacket();  // just eat them - they are not useful
 
 		if (_paramCount)
-			enforceEx!MYXProtocol(getEOFPacket(), "Expected EOF packet in result header sequence");
+			enforce!MYXProtocol(getEOFPacket(), "Expected EOF packet in result header sequence");
 
 		foreach(size_t i; 0.._colCount)
 		   _colDescriptions[i] = FieldDescription(_con.getPacket());
 
 		if (_colCount)
-			enforceEx!MYXProtocol(getEOFPacket(), "Expected EOF packet in result header sequence");
+			enforce!MYXProtocol(getEOFPacket(), "Expected EOF packet in result header sequence");
 	}
 
 	ParamDescription param(size_t i) pure const nothrow { return _paramDescriptions[i]; }

--- a/source/mysql/protocol/sockets.d
+++ b/source/mysql/protocol/sockets.d
@@ -55,8 +55,8 @@ class MySQLSocketPhobos : MySQLSocket
 	/// The socket should already be open
 	this(PlainPhobosSocket socket)
 	{
-		enforceEx!MYX(socket, "Tried to use a null Phobos socket - Maybe the 'openSocket' callback returned null?");
-		enforceEx!MYX(socket.isAlive, "Tried to use a closed Phobos socket - Maybe the 'openSocket' callback created a socket but forgot to open it?");
+		enforce!MYX(socket, "Tried to use a null Phobos socket - Maybe the 'openSocket' callback returned null?");
+		enforce!MYX(socket.isAlive, "Tried to use a closed Phobos socket - Maybe the 'openSocket' callback created a socket but forgot to open it?");
 		this.socket = socket;
 	}
 
@@ -86,8 +86,8 @@ class MySQLSocketPhobos : MySQLSocket
 
 		for (size_t off, len; off < dst.length; off += len) {
 			len = socket.receive(dst[off..$]);
-			enforceEx!MYX(len != 0, "Server closed the connection");
-			enforceEx!MYX(len != socket.ERROR, "Received std.socket.Socket.ERROR");
+			enforce!MYX(len != 0, "Server closed the connection");
+			enforce!MYX(len != socket.ERROR, "Received std.socket.Socket.ERROR");
 		}
 	}
 
@@ -111,8 +111,8 @@ version(Have_vibe_d_core) {
 		/// The socket should already be open
 		this(PlainVibeDSocket socket)
 		{
-			enforceEx!MYX(socket, "Tried to use a null Vibe.d socket - Maybe the 'openSocket' callback returned null?");
-			enforceEx!MYX(socket.connected, "Tried to use a closed Vibe.d socket - Maybe the 'openSocket' callback created a socket but forgot to open it?");
+			enforce!MYX(socket, "Tried to use a null Vibe.d socket - Maybe the 'openSocket' callback returned null?");
+			enforce!MYX(socket.connected, "Tried to use a closed Vibe.d socket - Maybe the 'openSocket' callback created a socket but forgot to open it?");
 			this.socket = socket;
 		}
 

--- a/source/mysql/result.d
+++ b/source/mysql/result.d
@@ -67,8 +67,8 @@ public:
 	+/
 	inout(Variant) opIndex(size_t i) inout
 	{
-		enforceEx!MYX(_nulls.length > 0, format("Cannot get column index %d. There are no columns", i));
-		enforceEx!MYX(i < _nulls.length, format("Cannot get column index %d. The last available index is %d", i, _nulls.length-1));
+		enforce!MYX(_nulls.length > 0, format("Cannot get column index %d. There are no columns", i));
+		enforce!MYX(i < _nulls.length, format("Cannot get column index %d. The last available index is %d", i, _nulls.length-1));
 		return _values[i];
 	}
 
@@ -111,7 +111,7 @@ public:
 			{
 				if(!_nulls[i])
 				{
-					enforceEx!MYX(_values[i].convertsTo!(typeof(s.tupleof[i].get))(),
+					enforce!MYX(_values[i].convertsTo!(typeof(s.tupleof[i].get))(),
 						"At col "~to!string(i)~" the value is not implicitly convertible to the structure type");
 					s.tupleof[i] = _values[i].get!(typeof(s.tupleof[i].get));
 				}
@@ -122,7 +122,7 @@ public:
 			{
 				if(!_nulls[i])
 				{
-					enforceEx!MYX(_values[i].convertsTo!(typeof(s.tupleof[i]))(),
+					enforce!MYX(_values[i].convertsTo!(typeof(s.tupleof[i]))(),
 						"At col "~to!string(i)~" the value is not implicitly convertible to the structure type");
 					s.tupleof[i] = _values[i].get!(typeof(s.tupleof[i]));
 				}
@@ -185,7 +185,7 @@ private:
 
 	void ensureValid() const pure
 	{
-		enforceEx!MYXInvalidatedRange(isValid,
+		enforce!MYXInvalidatedRange(isValid,
 			"This ResultRange has been invalidated and can no longer be used.");
 	}
 
@@ -230,7 +230,7 @@ public:
 	@property inout(Row) front() pure inout
 	{
 		ensureValid();
-		enforceEx!MYX(!empty, "Attempted 'front' on exhausted result sequence.");
+		enforce!MYX(!empty, "Attempted 'front' on exhausted result sequence.");
 		return _row;
 	}
 
@@ -240,7 +240,7 @@ public:
 	void popFront()
 	{
 		ensureValid();
-		enforceEx!MYX(!empty, "Attempted 'popFront' when no more rows available");
+		enforce!MYX(!empty, "Attempted 'popFront' when no more rows available");
 		_row = _con.getNextRow();
 		_numRowsFetched++;
 	}
@@ -253,7 +253,7 @@ public:
 	Variant[string] asAA()
 	{
 		ensureValid();
-		enforceEx!MYX(!empty, "Attempted 'front' on exhausted result sequence.");
+		enforce!MYX(!empty, "Attempted 'front' on exhausted result sequence.");
 		Variant[string] aa;
 		foreach (size_t i, string s; _colNames)
 			aa[s] = _row._values[i];


### PR DESCRIPTION
As of dmd-2.080.0, `enforceEx` is deprecated and should be replaced with `enforce`.