### PR TITLE
Expose column names in row struct

### DIFF
--- a/source/mysql/protocol/comms.d
+++ b/source/mysql/protocol/comms.d
@@ -636,7 +636,7 @@ body
 
 // Moved here from `struct Row.this`
 package(mysql) void ctorRow(Connection conn, ref ubyte[] packet, ResultSetHeaders rh, bool binary,
-	out Variant[] _values, out bool[] _nulls)
+	out Variant[] _values, out bool[] _nulls, out string[] _names)
 in
 {
 	assert(rh.fieldCount <= uint.max);
@@ -646,7 +646,7 @@ body
 	scope(failure) conn.kill();
 
 	uint fieldCount = cast(uint)rh.fieldCount;
-	_values.length = _nulls.length = fieldCount;
+	_values.length = _nulls.length = _names.length = fieldCount;
 
 	if(binary)
 	{
@@ -669,6 +669,7 @@ body
 		do
 		{
 			FieldDescription fd = rh[i];
+			_names[i] = fd.name;
 			sqlValue = packet.consumeIfComplete(fd.type, binary, fd.unsigned, fd.charSet);
 			// TODO: Support chunk delegate
 			if(sqlValue.isIncomplete)

--- a/source/mysql/result.d
+++ b/source/mysql/result.d
@@ -35,6 +35,7 @@ package:
 	Variant[]   _values; // Temporarily "package" instead of "private"
 private:
 	bool[]      _nulls;
+	string[]    _names;
 
 public:
 
@@ -51,7 +52,7 @@ public:
 	+/
 	this(Connection con, ref ubyte[] packet, ResultSetHeaders rh, bool binary)
 	{
-		ctorRow(con, packet, rh, binary, _values, _nulls);
+		ctorRow(con, packet, rh, binary, _values, _nulls, _names);
 	}
 
 	/++
@@ -70,6 +71,14 @@ public:
 		enforce!MYX(_nulls.length > 0, format("Cannot get column index %d. There are no columns", i));
 		enforce!MYX(i < _nulls.length, format("Cannot get column index %d. The last available index is %d", i, _nulls.length-1));
 		return _values[i];
+	}
+
+	/++
+	Get the name of the column with specified index.
+	+/
+	inout(string) getName(size_t index) inout
+	{
+		return _names[index];
 	}
 
 	/++


### PR DESCRIPTION
mysql-native's toStruct is quite limited currently (e.g. when compared to mysql-lited or `vibe.data` serialization). A better implementation is blocked mainly by the fact, that the `Row` does currently not know the column names. Only indices are available (but these depend on the sql query string, so it's also not easily possible to recover field names from these ids).

This PR simply exposes the names of the columns. A basic `toStruct` mapper could then look like this:
```d
T parse(T)(const Row row)
{
    T result;
    row.parse(result);
    return result;
}

void parse(T)(const Row row, ref T result)
{
    foreach (size_t i, name; row.names)
    {
        result.setField(name, row[i]);
    }
}

void setField(T)(ref T result, string name, Variant value)
{
    import std.traits;

    foreach (idx, member; result.tupleof)
    {
        enum mname = T.tupleof[idx].stringof;
        if (name == mname)
        {
            alias FieldType = typeof(__traits(getMember, result, mname));
            convertField!FieldType(__traits(getMember, result, mname), value);
        }
    }
}

void convertField(T)(ref T field, Variant value)
{
    import std.traits, std.datetime;
    alias UT = Unqual!T;

    // Convert between varian of possily typeof(null) and Nullable!T
    static if (is(typeof(UT.nullify)))
    {
        if (value.type == typeid(typeof(null)))
            field.nullify();
        else
            field = value.coerce!(Unqual!(ReturnType!(UT.get)));
    }
    else static if (is(UT == DateTime))
    {
        field = value.get!UT;
    }
    // All other types
    else
    {
        field = value.coerce!UT;
    }
}
```