### PR TITLE
Add cleanup function.

### DIFF
--- a/source/mysql/pool.d
+++ b/source/mysql/pool.d
@@ -62,7 +62,7 @@ version(IncludeMySQLPool)
 
 			/// See: $(LINK https://github.com/vibe-d/vibe-core/blob/24a83434e4c788ebb9859dfaecbe60ad0f6e9983/source/vibe/core/connectionpool.d#L113)
 			void removeUnused(scope void delegate(Connection conn) @safe nothrow disconnect_callback)
-            {}
+			{}
 		}
 
 		/++
@@ -448,9 +448,16 @@ version(IncludeMySQLPool)
 			Removes all unused connections from the pool. This can
 			be used to clean up before exiting the program to
 			ensure the event core driver can be properly shut down.
+
+			Note: this is only available if vibe-core 1.7.0 or later is being
+			used.
 			+/
 			void removeUnusedConnections() @safe
 			{
+				// Note: we squelch all exceptions here, because vibe-core
+				// requires the function be nothrow, and because an exception
+				// thrown while closing is probably not important enough to
+				// interrupt cleanup.
 				m_pool.removeUnused((conn) @trusted nothrow {
 					try {
 						conn.close();


### PR DESCRIPTION
Vibe-core now includes a mechanism to clean up all unused connection pool connections so the event driver can be properly destroyed. The way mysql-native's pool wraps vibe's ConnectionPool makes it difficult to reproduce the same functionality AND provide access to the cleanup function. In addition, this makes sure it does the cleanup properly.

In my code, if I don't have this function, I get "Leaking eventcore driver" messages.

I tried to make sure this properly shows up in the docs, we'll see what happens. I also tried to ensure this function only gets defined for vibe-core that supports it (requires 0.8.6). We will see if the CI accepts that.