### PR TITLE
Replace `mainSourceFile` with `excludedSourceFile` in unittest build 

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -35,11 +35,10 @@ configuration "unittest-vibe" {
 	targetType "executable"
 	targetPath "bin/"
 	targetName "mysqln-tests-vibe"
-	excludedSourceFiles "source/app.d"
+	excludedSourceFiles "source/app.d" "source/mysql/package.d"
 
 	dependency "vibe-core" version="~>1.16.0" optional=false
 
-	// mainSourceFile "source/mysql/package.d"
 	debugVersions "MYSQLN_TESTS"
 }
 


### PR DESCRIPTION
The directive wasn't using `mainSourceFile`,
because the configuration was only for testing.