### PR TITLE
Change to a more open vibe dependency.

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -4,7 +4,7 @@ license     "BSL-1.0"
 copyright   "Copyright (c) 2011-2021 Steve Teale, James W. Oliphant, Simen Endsjø, Sönke Ludwig, Sergey Shamov, Nick Sabalausky, and Steven Schveighoffer"
 authors     "Steve Teale" "James W. Oliphant" "Simen Endsjø" "Sönke Ludwig" "Sergey Shamov" "Nick Sabalausky" "Steven Schveighoffer"
 
-dependency "vibe-core" version="~>1.16.0" optional=true
+dependency "vibe-core" version=">=1.16.0" optional=true
 
 toolchainRequirements frontend=">=2.068"
 

--- a/integration-tests-vibe/dub.sdl
+++ b/integration-tests-vibe/dub.sdl
@@ -5,5 +5,5 @@ copyright   "Copyright (c) 2011-2021 Steve Teale, James W. Oliphant, Simen Endsj
 authors     "Steve Teale" "James W. Oliphant" "Simen Endsjø" "Sönke Ludwig" "Sergey Shamov" "Nick Sabalausky" "Steven Schveighoffer"
 
 dependency "mysql-native:integration-tests" path="../"
-dependency "vibe-core" version="~>1.16.0"
+dependency "vibe-core" version=">=1.16.0"
 targetType "executable"


### PR DESCRIPTION
This allows any vibe-core dependency that is after 1.16.0. We may even relax the lower end if it makes sense.