### PR TITLE
s/body/do/ in contracts, valid for ~4 years

### DIFF
--- a/source/mysql/connection.d
+++ b/source/mysql/connection.d
@@ -424,7 +424,7 @@ package:
 	{
 		assert(_open == OpenState.authenticated);
 	}
-	body
+	do
 	{
 		initConnection();
 		auto greeting = this.parseGreeting();
@@ -600,7 +600,7 @@ public:
 			case MySQLSocketType.vibed:  assert(openSocketVibeD  !is null); break;
 		}
 	}
-	body
+	do
 	{
 		enforce!MYX(capFlags & SvrCapFlags.PROTOCOL41, "This client only supports protocol v4.1");
 		enforce!MYX(capFlags & SvrCapFlags.SECURE_CONNECTION, "This client only supports protocol v4.1 connection");
@@ -724,7 +724,7 @@ public:
 	{
 		assert(_open == OpenState.authenticated);
 	}
-	body
+	do
 	{
 		this.sendCmd(CommandType.QUIT, []);
 		// No response is sent for a quit packet

--- a/source/mysql/prepared.d
+++ b/source/mysql/prepared.d
@@ -373,7 +373,7 @@ package struct PreparedRegistrations(Payload)
 		// let's make sure that doesn't change.
 		assert(!info.queuedForRelease);
 	}
-	body
+	do
 	{
 		if(auto pInfo = sql in directLookup)
 		{

--- a/source/mysql/protocol/comms.d
+++ b/source/mysql/protocol/comms.d
@@ -602,7 +602,7 @@ out(result)
 {
 	assert(result.length == numFields);
 }
-body
+do
 {
 	bool[] nulls;
 	nulls.length = numFields;
@@ -642,7 +642,7 @@ in
 {
 	assert(rh.fieldCount <= uint.max);
 }
-body
+do
 {
 	scope(failure) conn.kill();
 
@@ -716,7 +716,7 @@ in
 {
 	assert(packet.length > 4); // at least 1 byte more than header
 }
-body
+do
 {
 	_socket.write(packet);
 }
@@ -726,7 +726,7 @@ in
 {
 	assert(header.length == 4 || header.length == 5/*command type included*/);
 }
-body
+do
 {
 	_socket.write(header);
 	if(data.length)
@@ -756,7 +756,7 @@ out
 	// at this point we should have sent a command
 	assert(conn.pktNumber == 1);
 }
-body
+do
 {
 	scope(failure) conn.kill();
 
@@ -797,7 +797,7 @@ in
 {
 	assert(token.length == 20);
 }
-body
+do
 {
 	ubyte[] packet;
 	packet.reserve(4/*header*/ + 4 + 4 + 1 + 23 + conn._user.length+1 + token.length+1 + conn._db.length+1);
@@ -981,7 +981,7 @@ out
 {
 	assert(conn._open == Connection.OpenState.authenticated);
 }
-body
+do
 {
 	auto token = makeToken(conn._pwd, greeting);
 	auto authPacket = conn.buildAuthPacket(token);

--- a/source/mysql/protocol/packet_helpers.d
+++ b/source/mysql/protocol/packet_helpers.d
@@ -354,7 +354,7 @@ in
 {
 	assert(packet.length >= N);
 }
-body
+do
 {
 	return cast(string)packet.consume(N);
 }
@@ -365,7 +365,7 @@ in
 {
 	assert(packet.length >= N);
 }
-body
+do
 {
 	auto result = packet[0..N];
 	packet = packet[N..$];
@@ -404,7 +404,7 @@ in
 {
 	static assert(N == T.sizeof);
 }
-body
+do
 {
 	enforce!MYXProtocol(packet.length, "Supplied byte array is zero length");
 	uint length = packet.front;
@@ -427,7 +427,7 @@ in
 {
 	static assert(N == T.sizeof);
 }
-body
+do
 {
 	return toDate(packet.consume(5));
 }
@@ -438,7 +438,7 @@ in
 	assert(packet.length);
 	assert(N == T.sizeof);
 }
-body
+do
 {
 	auto numBytes = packet.consume!ubyte();
 	if(numBytes == 0)
@@ -468,7 +468,7 @@ in
 {
 	static assert(T.sizeof >= N, T.stringof~" not large enough to store "~to!string(N)~" bytes");
 }
-body
+do
 {
 	return packet.length >= N;
 }
@@ -481,7 +481,7 @@ in
 	static assert(T.sizeof >= N, T.stringof~" not large enough to store "~to!string(N)~" bytes");
 	assert(packet.hasEnoughBytes!(T,N), "packet not long enough to contain all bytes needed for "~T.stringof);
 }
-body
+do
 {
 	T value = 0;
 	static if(N == 8) // 64 bit
@@ -518,7 +518,7 @@ in
 	static assert(T.sizeof >= N, T.stringof~" not large enough to store "~to!string(N)~" bytes");
 	assert(packet.hasEnoughBytes!(T,N), "packet not long enough to contain all bytes needed for "~T.stringof);
 }
-body
+do
 {
 	// The uncommented line triggers a template deduction error,
 	// so we need to store a temporary first
@@ -548,7 +548,7 @@ in
 	static assert((is(T == float) && N == float.sizeof)
 			|| is(T == double) && N == double.sizeof);
 }
-body
+do
 {
 	T result = 0;
 	(cast(ubyte*)&result)[0..T.sizeof] = packet[0..T.sizeof];
@@ -562,7 +562,7 @@ in
 	static assert((is(T == float) && N == float.sizeof)
 			|| is(T == double) && N == double.sizeof);
 }
-body
+do
 {
 	return packet.consume(T.sizeof).decode!T();
 }
@@ -785,7 +785,7 @@ in
 {
 	assert(packet.length >= 1, "packet has to include at least the LCB length byte");
 }
-body
+do
 {
 	auto lcb = packet.decodeLCBHeader();
 	if(lcb.isNull || lcb.isIncomplete)
@@ -809,7 +809,7 @@ in
 {
 	assert(packet.length >= 1, "packet has to include at least the LCB length byte");
 }
-body
+do
 {
 	LCB lcb;
 	lcb.numBytes = getNumLCBBytes(packet.front);
@@ -849,7 +849,7 @@ in
 {
 	assert(packet.length >= 1, "packet has to include at least the LCB length byte");
 }
-body
+do
 {
 	auto lcb = packet.decodeLCBHeader();
 	if(lcb.isNull || lcb.isIncomplete)
@@ -879,7 +879,7 @@ in
 {
 	assert(packet.length >= 1, "LCS packet needs to store at least the LCB header");
 }
-body
+do
 {
 	auto lcb = packet.consumeIfComplete!LCB();
 	assert(!lcb.isIncomplete);
@@ -898,7 +898,7 @@ in
 {
 	assert(n <= array.length);
 }
-body
+do
 {
 	array = array[n..$];
 	return array;
@@ -921,7 +921,7 @@ in
 	else
 		assert(array.length >= T.sizeof, "Not enough space to unpack "~T.stringof);
 }
-body
+do
 {
 	static if(T.sizeof >= 1)
 	{
@@ -957,7 +957,7 @@ out(result)
 {
 	assert(result.length >= 1);
 }
-body
+do
 {
 	ubyte[] t;
 	if (!l)
@@ -1122,7 +1122,7 @@ in
 	// packet should include header, and possibly data
 	assert(packet.length >= 4);
 }
-body
+do
 {
 	auto dataLength = packet.length - 4; // don't include header in calculated size
 	assert(dataLength <= uint.max);
@@ -1137,7 +1137,7 @@ in
 	// Length is always a 24-bit int
 	assert(dataLength <= 0xffff_ffff_ffff);
 }
-body
+do
 {
 	dataLength.packInto!(uint, true)(packet);
 	packet[3] = packetNumber;

--- a/source/mysql/protocol/packets.d
+++ b/source/mysql/protocol/packets.d
@@ -124,7 +124,7 @@ public:
 	{
 		assert(!packet.length, "not all bytes read during FieldDescription construction");
 	}
-	body
+	do
 	{
 		packet.skip(4); // Skip catalog - it's always 'def'
 		_db             = packet.consume!LCS();
@@ -245,7 +245,7 @@ in
 {
 	assert(!packet.empty);
 }
-body
+do
 {
 	return packet.front == ResultPacketMarker.eof && packet.length < 9;
 }
@@ -286,7 +286,7 @@ public:
 	{
 		assert(!packet.length);
 	}
-	body
+	do
 	{
 		packet.popFront(); // eof marker
 		_warnings = packet.consume!short();

--- a/source/mysql/result.d
+++ b/source/mysql/result.d
@@ -287,7 +287,7 @@ public:
 	/// Explicitly clean up the MySQL resources and cancel pending results
 	void close()
 	out{ assert(!isValid); }
-	body
+	do
 	{
 		if(isValid)
 			_con.purgeResult();


### PR DESCRIPTION
I've got a #! dub script that uses mysql-native, and starting it results in 37 lines of deprecation warnings. This PR silences them by switching to the new syntax (confirmed with `dub add-local`)

ref: https://github.com/dlang/dmd/commit/fb67500999a7c9f3c793ad9f0a9dd181a23f7aa4

