### PR TITLE
Fix issue #222. Set column names even for null columns

### DIFF
--- a/integration-tests/source/mysql/maintests.d
+++ b/integration-tests/source/mysql/maintests.d
@@ -1335,3 +1335,17 @@ unittest
 	assert(rows[1].getName(0) == "another");
 	assert(rows[1].getName(1) == "someValue");
 }
+
+// issue 222, set column names when data is null.
+@("colNamesForBinary")
+debug(MYSQLN_TESTS)
+unittest
+{
+	import mysql.test.common;
+	import mysql.commands;
+	mixin(scopedCn);
+	// binary mode happens with prepared statements
+	auto row = cn.queryRow("SELECT `colname` FROM (SELECT 1 AS `id`, NULL AS `colname`) as `tbl` WHERE `id` = ?", 1);
+	assert(row.get[0] == null);
+	assert(row.get.getName(0) == "colname");
+}

--- a/source/mysql/protocol/comms.d
+++ b/source/mysql/protocol/comms.d
@@ -663,6 +663,7 @@ do
 		if(binary && _nulls[i])
 		{
 			_values[i] = null;
+			_names[i] = rh[i].name;
 			continue;
 		}
 


### PR DESCRIPTION
I'm already not a huge fan of how this is done anyway (we are creating a new array for *every* row containing the names, even though the array never changes). But this at least should fix the bug at hand.