### PR TITLE
Add a GH Workflow for the Generation and Deployment of Documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+# Builds the documentation, with the latest adrdox, with every push to master,
+# and deploys it to the gh-pages branch. Derived from Paul Backus'
+# https://github.com/pbackus/sumtype/blob/master/.github/workflows/docs.yml.
+
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Install D compiler
+        uses: dlang-community/setup-dlang@v1
+        with:
+          compiler: dmd-latest
+
+      - name: Build documentation
+        run: |
+          wget https://github.com/adamdruppe/adrdox/archive/master.zip
+          unzip master.zip
+          pushd adrdox-master && make && popd
+          export PATH=$PATH:$PWD/adrdox-master
+          doc2 --genSearchIndex --genSource -o generated-docs source
+
+      - name: Deploy to Github Pages
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: generated-docs


### PR DESCRIPTION
What it says on the tin: This PR adds a GitHub workflow that will generate documentation upon every push to master and deploy it to the `gh-pages`* branch. The PR is purely additive: the previous method of generating the documentation is kept. Further, **as a possible perquisite to merging**, a `gh-pages` branch of this repo might need to be created depending on whether the runner can automatically create branches.

Instead of using a bespoke ddox, [adrdox](https://github.com/adamdruppe/adrdox) is employed. While I'm ignorant as to what changes were made to this repository's version of ddox from vanilla, from my experience, adrdox just werks, and it's actively maintained.

Finally, the workflow file is derived from Paul Backus' [docs.yml for his sumtype repository](https://github.com/pbackus/sumtype/blob/master/.github/workflows/docs.yml). I made few, very minor edits; this PR message consumed more time than the actual changes.

\* The `gh-pages` identifier is arbitrary, but it is the default one used by GitHub when sourcing data for Pages.