### PR TITLE
Add not-null contract to `prepare()` function

### DIFF
--- a/source/mysql/safe/connection.d
+++ b/source/mysql/safe/connection.d
@@ -43,6 +43,7 @@ Params:
 	sql = The SQL statement to prepare.
 +/
 SafePrepared prepare(Connection conn, const(char[]) sql)
+	in(conn !is null)
 {
 	auto info = conn.registerIfNeeded(sql);
 	return SafePrepared(sql, info.headers, info.numParams);


### PR DESCRIPTION
If `conn` is null, this won't be caught until much later and results in segfaults happening in other places. Depending on the user's abstraction the real cause (`conn` is `null`) might no longer be too obvious.