### PR TITLE
Support for timestamps with sub second resolution.

### DIFF
--- a/source/mysql/impl/connection.d
+++ b/source/mysql/impl/connection.d
@@ -327,12 +327,15 @@ package(mysql):
 	/// Releases all prepared statements that are queued for release.
 	void releaseQueued()
 	{
+		const(char)[][] toRemove;
 		foreach(sql, info; preparedRegistrations.directLookup)
-		if(info.queuedForRelease)
-		{
-			immediateReleasePrepared(this, info.statementId);
+			if(info.queuedForRelease)
+			{
+				immediateReleasePrepared(this, info.statementId);
+				toRemove ~= sql;
+			}
+		foreach(sql;toRemove)
 			preparedRegistrations.directLookup.remove(sql);
-		}
 	}
 
 	/// Returns null if not found

--- a/source/mysql/impl/prepared.d
+++ b/source/mysql/impl/prepared.d
@@ -24,6 +24,7 @@ import mysql.protocol.packets;
 import mysql.types;
 import mysql.impl.result;
 import mysql.safe.commands : ColumnSpecialization, CSN;
+import std.datetime : DateTime;
 
 /++
 A struct to represent specializations of prepared statement parameters.
@@ -153,11 +154,19 @@ public:
 
 		enforce!MYX(index < _numParams, "Parameter index out of range.");
 
-		_inParams[index] = val;
+		static if ((is (T == DateTime)) || (is (T == const(DateTime)))|| (is (T == immutable(DateTime))))
+		{
+			_inParams[index] = DateTimeExt(val,0);
+		}
+		else
+		{
+			_inParams[index] = val;
+		}
 		psn.pIndex = index;
 		_psa[index] = psn;
 	}
 
+	
 	///ditto
 	void setArg(T)(size_t index, Nullable!T val, SafeParameterSpecialization psn = SPSN.init)
 	{

--- a/source/mysql/protocol/packet_helpers.d
+++ b/source/mysql/protocol/packet_helpers.d
@@ -322,7 +322,7 @@ ubyte[] pack(in DateTimeExt dt) pure nothrow
 	uint len = 1;
 	if (dt.year || dt.month || dt.day) len = 5;
 	if (dt.hour || dt.minute|| dt.second) len = 8;
-	if (dt.msecs) len = 12;
+	if (dt.u_seconds) len = 12;
 	ubyte[] rv;
 	rv.length = len;
 	rv[0] =  cast(ubyte)(rv.length - 1); // num bytes
@@ -341,10 +341,10 @@ ubyte[] pack(in DateTimeExt dt) pure nothrow
 	}
 	if (len == 12)
 	{
-		rv[8] = cast(ubyte)dt.msecs;
-		rv[9] = cast(ubyte)(dt.msecs >> 8);
-		rv[10] = cast(ubyte)(dt.msecs >> 16);
-		rv[11] = cast(ubyte)(dt.msecs >> 24);
+		rv[8] = cast(ubyte)dt.u_seconds;
+		rv[9] = cast(ubyte)(dt.u_seconds >> 8);
+		rv[10] = cast(ubyte)(dt.u_seconds >> 16);
+		rv[11] = cast(ubyte)(dt.u_seconds >> 24);
 	}
 	return rv;
 }
@@ -466,7 +466,7 @@ do
 	int hour    = 0;
 	int minute  = 0;
 	int second  = 0;
-	int msecs = 0;
+	int u_seconds = 0;
 	if(numBytes > 4)
 	{
 		enforce!MYXProtocol(numBytes >= 7, "Supplied packet is not large enough to store a DateTime with TimeOfDay");
@@ -476,9 +476,9 @@ do
 	}
 	if (numBytes >= 11)
 	{
-		msecs = packet.consume!uint;
+		u_seconds = packet.consume!uint;
 	}
-	return DateTimeExt(DateTime(year, month, day, hour, minute, second),msecs);
+	return DateTimeExt(DateTime(year, month, day, hour, minute, second),u_seconds);
 }
 
 

--- a/source/mysql/protocol/packet_helpers.d
+++ b/source/mysql/protocol/packet_helpers.d
@@ -593,8 +593,8 @@ SQLValue consumeBinaryValueIfComplete(T, int N=T.sizeof)(ref ubyte[] packet, boo
 {
 	SQLValue result;
 
-	// Length of DateTime packet is NOT DateTime.sizeof, it can be 1, 5 or 8 bytes
-	static if(is(T==DateTime))
+	// Length of DateTime packet is NOT DateTime.sizeof, it can be 1, 5 or 8 or 12 bytes
+	static if(is(T==DateTimeExt))
 		result.isIncomplete = packet.length < 1;
 	else
 		result.isIncomplete = packet.length < N;

--- a/source/mysql/protocol/packet_helpers.d
+++ b/source/mysql/protocol/packet_helpers.d
@@ -461,6 +461,8 @@ do
 		hour    = packet.consume!ubyte();
 		minute  = packet.consume!ubyte();
 		second  = packet.consume!ubyte();
+		foreach(i;7..numBytes)
+			packet.consume!ubyte();
 	}
 	return DateTime(year, month, day, hour, minute, second);
 }

--- a/source/mysql/protocol/packet_helpers.d
+++ b/source/mysql/protocol/packet_helpers.d
@@ -333,18 +333,18 @@ ubyte[] pack(in DateTimeExt dt) pure nothrow
 		rv[3] = cast(ubyte)   dt.month;
 		rv[4] = cast(ubyte)   dt.day;
 	}
-	if(len == 8)
+	if(len >= 8)
 	{
 		rv[5] = cast(ubyte) dt.hour;
 		rv[6] = cast(ubyte) dt.minute;
 		rv[7] = cast(ubyte) dt.second;
 	}
-	if (len == 12)
+	if (len >= 12)
 	{
-		rv[8] = cast(ubyte)dt.u_seconds;
-		rv[9] = cast(ubyte)(dt.u_seconds >> 8);
-		rv[10] = cast(ubyte)(dt.u_seconds >> 16);
-		rv[11] = cast(ubyte)(dt.u_seconds >> 24);
+		rv[8] = cast(ubyte)(dt.u_seconds & 0x0ff);
+		rv[9] = cast(ubyte)((dt.u_seconds >> 8) & 0x0ff);
+		rv[10] = cast(ubyte)((dt.u_seconds >> 16) & 0x0ff);
+		rv[11] = cast(ubyte)((dt.u_seconds >> 24) & 0x0ff);
 	}
 	return rv;
 }

--- a/source/mysql/types.d
+++ b/source/mysql/types.d
@@ -1,7 +1,7 @@
 /// Structures for MySQL types not built-in to D/Phobos.
 module mysql.types;
 import taggedalgebraic.taggedalgebraic;
-import std.datetime : DateTime, TimeOfDay, Date, SysTime,TimeZone;
+import std.datetime : DateTime, TimeOfDay, Date, SysTime,TimeZone,usecs;
 import std.typecons : Nullable;
 import std.format;
 
@@ -45,9 +45,12 @@ struct DateTimeExt
 	uint u_seconds;
 	string toString() pure nothrow @safe const
 	{
-		return dt.toString ~ format(".%06d",this.u_seconds);
+		try
+			return dt.toString ~ format(".%06d",this.u_seconds);
+		catch(Exception e)
+			assert(0,"DateTimeExt.toString threw");
 	}
-	SysTime makeSysTime(return scope immutable TimeZone tz = null) @safe const pure nothrow scope
+	SysTime makeSysTime(return scope immutable TimeZone tz = null) @safe const scope
 	{
 		return SysTime(dt,usecs(this.u_seconds),tz);
 	}

--- a/source/mysql/types.d
+++ b/source/mysql/types.d
@@ -42,15 +42,14 @@ struct DateTimeExt
 {
 	DateTime dt;
 	alias dt this;
-	uint usecs;
+	uint u_seconds;
 	string toString() pure nothrow @safe const
 	{
-		return dt.toString ~ format(".%06d",this.usecs);
+		return dt.toString ~ format(".%06d",this.u_seconds);
 	}
-	SysTime opCast(T)() @safe const pure nothrow scope
-		if (is(immutable T == immutable SysTime))
+	SysTime makeSysTime(return scope immutable TimeZone tz = null) @safe const pure nothrow scope
 	{
-		return SysTime(dt) + .usecs(this.usecs);
+		return SysTime(dt,usecs(this.u_seconds),tz);
 	}
 }
 

--- a/source/mysql/types.d
+++ b/source/mysql/types.d
@@ -3,6 +3,7 @@ module mysql.types;
 import taggedalgebraic.taggedalgebraic;
 import std.datetime : DateTime, TimeOfDay, Date;
 import std.typecons : Nullable;
+import std.conv;
 
 /++
 A simple struct to represent time difference.

--- a/source/mysql/types.d
+++ b/source/mysql/types.d
@@ -42,6 +42,10 @@ struct DateTimeExt
 	DateTime dt;
 	alias dt this;
 	uint msecs;
+	string toString() pure nothrow @safe const
+	{
+		return dt.toString ~ "." ~ to!string(msecs);
+	}
 }
 
 

--- a/source/mysql/types.d
+++ b/source/mysql/types.d
@@ -46,7 +46,7 @@ struct DateTimeExt
 	string toString() pure nothrow @safe const
 	{
 		try
-			return dt.toString ~ format(".%06d",this.u_seconds);
+			return dt.date.toISOExtString ~ " " ~ dt.timeOfDay.toISOExtString ~ format(".%06d",this.u_seconds);
 		catch(Exception e)
 			assert(0,"DateTimeExt.toString threw");
 	}

--- a/source/mysql/types.d
+++ b/source/mysql/types.d
@@ -33,6 +33,18 @@ struct Timestamp
 	ulong rep;
 }
 
+/++
+A D struct to stand for a DateTime with sub second resolution
+
++/
+struct DateTimeExt
+{
+	DateTime dt;
+	alias dt this;
+	uint msecs;
+}
+
+
 private union _MYTYPE
 {
 @safeOnly:
@@ -54,7 +66,7 @@ private union _MYTYPE
 	long Long;
 	float Float;
 	double Double;
-	.DateTime DateTime;
+	DateTimeExt DateTime;
 	TimeOfDay Time;
 	.Timestamp Timestamp;
 	.Date Date;
@@ -74,7 +86,7 @@ private union _MYTYPE
 	const(long)* LongRef;
 	const(float)* FloatRef;
 	const(double)* DoubleRef;
-	const(.DateTime)* DateTimeRef;
+	const(DateTimeExt)* DateTimeRef;
 	const(TimeOfDay)* TimeRef;
 	const(.Date)* DateRef;
 	const(string)* TextRef;
@@ -209,7 +221,7 @@ package MySQLVal _toVal(Variant v)
 			enum FQN = T.stringof;
 	}
 
-	alias BasicTypes = AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong, float, double, DateTime, TimeOfDay, Date, Timestamp);
+	alias BasicTypes = AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong, float, double, DateTimeExt, TimeOfDay, Date, Timestamp);
 	alias ArrayTypes = AliasSeq!(char[], const(char)[],
 								 ubyte[], const(ubyte)[], immutable(ubyte)[]);
 

--- a/source/mysql/types.d
+++ b/source/mysql/types.d
@@ -54,6 +54,17 @@ struct DateTimeExt
 	{
 		return SysTime(dt,usecs(this.u_seconds),tz);
 	}
+	DateTimeExt opAssign(const DateTime x) @safe
+	{
+		dt = x;
+		u_seconds  = 0;
+		return this;
+	}
+	DateTime opCast(T)()
+	if (is(T == DateTime))
+	{
+		return dt;
+	}
 }
 
 

--- a/source/mysql/types.d
+++ b/source/mysql/types.d
@@ -1,9 +1,9 @@
 /// Structures for MySQL types not built-in to D/Phobos.
 module mysql.types;
 import taggedalgebraic.taggedalgebraic;
-import std.datetime : DateTime, TimeOfDay, Date;
+import std.datetime : DateTime, TimeOfDay, Date, SysTime;
 import std.typecons : Nullable;
-import std.conv;
+import std.format;
 
 /++
 A simple struct to represent time difference.
@@ -42,10 +42,15 @@ struct DateTimeExt
 {
 	DateTime dt;
 	alias dt this;
-	uint msecs;
+	uint usecs;
 	string toString() pure nothrow @safe const
 	{
-		return dt.toString ~ "." ~ to!string(msecs);
+		return dt.toString ~ format(".%06d",this.usecs);
+	}
+	SysTime opCast(T)() @safe const pure nothrow scope
+		if (is(immutable T == immutable SysTime))
+	{
+		return SysTime(dt) + .usecs(this.usecs);
 	}
 }
 

--- a/source/mysql/types.d
+++ b/source/mysql/types.d
@@ -1,7 +1,7 @@
 /// Structures for MySQL types not built-in to D/Phobos.
 module mysql.types;
 import taggedalgebraic.taggedalgebraic;
-import std.datetime : DateTime, TimeOfDay, Date, SysTime;
+import std.datetime : DateTime, TimeOfDay, Date, SysTime,TimeZone;
 import std.typecons : Nullable;
 import std.format;
 


### PR DESCRIPTION
In Mariadb you can specify that a timestamp has finer than second resolution e.g. TIMESTAMP(3), this results in an extra 4 bytes in the timestamp packet.
datetime.DateTime only supports second resolution, so we can't do anything with them but they need to be consumed for the next value to be read correctly.